### PR TITLE
Prevent multiple definiton of global variable IID

### DIFF
--- a/src/iid_modules/iid_modules.c
+++ b/src/iid_modules/iid_modules.c
@@ -19,6 +19,8 @@ extern iid_module_t module_set;
 extern iid_module_t module_low_fill;
 // Add your module here
 
+uint8_t IID[IP_MAX_BYTES];
+
 iid_module_t *iid_modules[] = {
     &module_full, &module_low, &module_low_fill,
     &module_rand, &module_set, &module_zero,

--- a/src/iid_modules/iid_modules.h
+++ b/src/iid_modules/iid_modules.h
@@ -14,7 +14,7 @@
 
 #define IP_MAX_BYTES 16
 
-uint8_t IID[IP_MAX_BYTES]; // both for ipv4 & ipv6
+extern uint8_t IID[IP_MAX_BYTES]; // both for ipv4 & ipv6
 
 // called at sender initialization
 typedef int (*iid_global_init_cb)(struct state_conf *conf);


### PR DESCRIPTION
Use extern in declartion and define IID once.

Fixes #5: "multiple definition of" error when using GCC >= 10.